### PR TITLE
Add async pot save

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ extractor
 // save the extracted messages as Gettext template file
 extractor.savePotFile('./messages.pot');
 
+// or save the extracted messages asynchronously
+extractor.savePotFileAsync('./messages.pot')
+    .then(() => console.log('Done'))
+    .catch((err) => console.error(err.message));
+
 // print nice statistics about the extracted messages
 extractor.printStats();
 ```
@@ -96,7 +101,7 @@ All the configuration is done and we can get started with parsing. The method `p
 
 #### Saving as Template File
 
-With `savePotFile()` all extracted messages are written to the specified `.pot` file in Gettext format.
+With `savePotFile()` or `savePotFileAsync()` all extracted messages are written to the specified `.pot` file in Gettext format.
 
 #### Printing Statistics
 
@@ -359,6 +364,21 @@ msgstr[0] ""
 
 ---
 
+#### `savePotFileAsync(fileName)`
+
+*Saves the extracted messages as Gettext template into a file asynchronously.*
+
+##### Parameters
+
+| Name | Type | Details |
+| --- | --- | --- |
+| `fileName` | *string* | **Required** · Path to `.pot` file |
+
+##### Return Value
+
+*Promise*
+
+---
 
 #### `getStats()`
 

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -56,6 +56,19 @@ export class GettextExtractor {
         return gettextParser.po.compile({translations: this.toGettextMessages(), charset: 'UTF-8'}).toString();
     }
 
+    public savePotFileAsync(fileName: string): Promise<any> {
+        Validate.required.nonEmptyString({ fileName });
+
+        return new Promise((resolve, reject) => {
+            fs.writeFile(fileName, this.toPotString(), (err) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve();
+            });
+        });
+    }
+
     public savePotFile(fileName: string): void {
         Validate.required.nonEmptyString({fileName});
 

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -151,6 +151,26 @@ describe('GettextExtractor', () => {
             });
         });
 
+        describe('savePotFileAsync', () => {
+            test('fileName: (none)', () => {
+                expect(() => {
+                  (<any>extractor.savePotFileAsync)();
+                }).toThrowError(`Missing argument 'fileName'`);
+            });
+
+            test('message: null', () => {
+                expect(() => {
+                  (<any>extractor.savePotFileAsync)(null);
+                }).toThrowError(`Argument 'fileName' must be a non-empty string`);
+            });
+
+            test('message: wrong type', () => {
+                expect(() => {
+                  (<any>extractor.savePotFileAsync)(42);
+                }).toThrowError(`Argument 'fileName' must be a non-empty string`);
+            });
+        });
+
         describe('createJsParser', () => {
             test('extractors: (none)', () => {
                 expect(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "dist/",
-        "target": "ES5",
+        "target": "ES6",
         "module": "commonjs",
         "declaration": true,
         "newLine": "LF"


### PR DESCRIPTION
This PR adds single method that saves .pot file asynchronously - uses `fs.writeFile()` wrapped in `new Promise()` constructor.