### PR TITLE
Fix parsing of template elements

### DIFF
--- a/src/html/parser.ts
+++ b/src/html/parser.ts
@@ -28,8 +28,9 @@ export class HtmlParser extends Parser<IHtmlExtractorFunction, IParseOptions> {
             extractor(node, fileName, addMessageCallback);
         }
 
-        if (node.childNodes) {
-            for (let n of node.childNodes) {
+        let childNodes = node.content ? node.content.childNodes : node.childNodes;
+        if (childNodes) {
+            for (let n of childNodes) {
                 messages = messages.concat(this.parseNode(n, fileName, lineNumberStart));
             }
         }

--- a/tests/e2e/fixtures/html/template.expected.pot
+++ b/tests/e2e/fixtures/html/template.expected.pot
@@ -1,0 +1,24 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+#: tests/e2e/fixtures/html/template.html:2
+msgid "Logo"
+msgstr ""
+
+#: tests/e2e/fixtures/html/template.html:4
+msgctxt "Menu"
+msgid "{{n}} notification"
+msgid_plural "{{n}} notifications"
+msgstr[0] ""
+msgstr[1] ""
+
+#: tests/e2e/fixtures/html/template.html:6
+msgctxt "Menu"
+msgid "Logout"
+msgstr ""
+
+#: tests/e2e/fixtures/html/template.html:5
+msgctxt "Menu"
+msgid "Settings"
+msgstr ""

--- a/tests/e2e/fixtures/html/template.html
+++ b/tests/e2e/fixtures/html/template.html
@@ -1,0 +1,8 @@
+<template>
+    <img src="logo.png" translate-alt alt="Logo"/>
+    <ul class="user-menu">
+        <li translate translation-context="Menu" translate-plural="{{n}} notifications">{{n}} notification</li>
+        <li translate translation-context="Menu">Settings</li>
+        <li translate translation-context="Menu">Logout</li>
+    </ul>
+</template>

--- a/tests/e2e/html.test.ts
+++ b/tests/e2e/html.test.ts
@@ -21,6 +21,24 @@ describe('HTML E2E', () => {
         expect(extractor.getPotString()).toBe(fs.readFileSync(__dirname + '/fixtures/html/example.expected.pot').toString());
     });
 
+    test('template element', () => {
+        let extractor = new GettextExtractor();
+
+        extractor
+            .createHtmlParser([
+                HtmlExtractors.elementContent('[translate]', {
+                    attributes: {
+                        textPlural: 'translate-plural',
+                        context: 'translation-context'
+                    }
+                }),
+                HtmlExtractors.elementAttribute('[translate-alt]', 'alt')
+            ])
+            .parseFile('tests/e2e/fixtures/html/template.html');
+
+        expect(extractor.getPotString()).toBe(fs.readFileSync(__dirname + '/fixtures/html/template.expected.pot').toString());
+    });
+
     test('embedded js', () => {
         let extractor = new GettextExtractor();
 

--- a/tests/html/parser.test.ts
+++ b/tests/html/parser.test.ts
@@ -140,4 +140,27 @@ describe('HtmlParser', () => {
             check(UnicodeSamples.turkish);
         });
     });
+
+    test('template element', () => {
+        let parser: HtmlParser;
+        let builderMock: CatalogBuilder;
+
+        builderMock = <any>{
+            addMessage: jest.fn()
+        };
+        parser = new HtmlParser(builderMock, [(node: TextNode, fileName: string, addMessage) => {
+            if (node.nodeName === '#text') {
+                addMessage({
+                    text: node.value
+                });
+            }
+        }]);
+
+        parser.parseString(`<template>Foo</template>`, 'foo.html');
+
+        expect(builderMock.addMessage).toHaveBeenCalledWith({
+            text: 'Foo',
+            references: ['foo.html:1']
+        });
+    });
 });


### PR DESCRIPTION
Trying to extract message from [Aurelia templates](http://aurelia.io/docs/templating/basics) fails, because the html-parser does not find the child nodes of the `HTMLTemplateElement`.

Example HTML file:
```html
<template>
  <p translate>
    Hello, World!
  </p>
</template>
```

This PR fixes the html-parser so that child nodes of a `HTMLTemplateElement` are also traversed and translatable strings are extracted.