### PR TITLE
Implement JS template literal extractions

### DIFF
--- a/src/html/extractors/factories/elementContent.ts
+++ b/src/html/extractors/factories/elementContent.ts
@@ -1,24 +1,18 @@
 import { IHtmlExtractorFunction } from '../../parser';
-import { IElementContentOptions, HtmlUtils } from '../../utils';
+import { HtmlUtils } from '../../utils';
 import { Validate } from '../../../utils/validate';
+import { IContentOptions, IContentExtractorOptions, validateContentOptions } from '../../../utils/content';
 import { IHtmlExtractorOptions, validateOptions } from '../common';
 import { elementExtractor } from './element';
 
-export interface IElementContentExtractorOptions extends IHtmlExtractorOptions {
-    content?: Partial<IElementContentOptions>;
-}
+export interface IElementContentExtractorOptions extends IHtmlExtractorOptions, IContentExtractorOptions {}
 
 export function elementContentExtractor(selector: string, options: IElementContentExtractorOptions = {}): IHtmlExtractorFunction {
     Validate.required.nonEmptyString({selector});
     validateOptions(options);
-    Validate.optional.booleanProperty(options, 'options.content.trimWhiteSpace');
-    Validate.optional.booleanProperty(options, 'options.content.preserveIndentation');
-    if (options.content && options.content.replaceNewLines !== undefined
-        && options.content.replaceNewLines !== false && typeof options.content.replaceNewLines !== 'string') {
-        throw new TypeError(`Property 'options.content.replaceNewLines' must be false or a string`);
-    }
+    validateContentOptions(options);
 
-    let contentOptions: IElementContentOptions = {
+    let contentOptions: IContentOptions = {
         trimWhiteSpace: true,
         preserveIndentation: false,
         replaceNewLines: false

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -1,12 +1,7 @@
 import * as parse5 from 'parse5';
 
 import { Element } from './parser';
-
-export interface IElementContentOptions {
-    trimWhiteSpace: boolean;
-    preserveIndentation: boolean;
-    replaceNewLines: false | string;
-}
+import { IContentOptions, normalizeContent } from '../utils/content';
 
 export abstract class HtmlUtils {
 
@@ -19,7 +14,7 @@ export abstract class HtmlUtils {
         return null;
     }
 
-    public static getElementContent(element: Element, options: IElementContentOptions): string {
+    public static getElementContent(element: Element, options: IContentOptions): string {
         let content = parse5.serialize(element, {});
 
         // Un-escape characters that get escaped by parse5
@@ -28,16 +23,6 @@ export abstract class HtmlUtils {
             .replace(/&lt;/g, '<')
             .replace(/&gt;/g, '>');
 
-        if (options.trimWhiteSpace) {
-            content = content.replace(/^\n+|\s+$/g, '');
-        }
-        if (!options.preserveIndentation) {
-            content = content.replace(/^[ \t]+/mg, '');
-        }
-        if (typeof options.replaceNewLines === 'string') {
-            content = content.replace(/\n/g, options.replaceNewLines);
-        }
-
-        return content;
+        return normalizeContent(content, options);
     }
 }

--- a/src/js/extractors/common.ts
+++ b/src/js/extractors/common.ts
@@ -1,5 +1,6 @@
 import { Validate } from '../../utils/validate';
 import { ICommentOptions } from './comments';
+import { IContentOptions, IContentExtractorOptions } from '../../utils/content';
 
 export interface IArgumentIndexMapping {
     text: number;
@@ -7,7 +8,7 @@ export interface IArgumentIndexMapping {
     context?: number;
 }
 
-export interface IJsExtractorOptions {
+export interface IJsExtractorOptions extends IContentExtractorOptions {
     arguments: IArgumentIndexMapping;
     comments?: ICommentOptions;
 }

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,0 +1,34 @@
+import { Validate } from './validate';
+
+export interface IContentOptions {
+    trimWhiteSpace: boolean;
+    preserveIndentation: boolean;
+    replaceNewLines: false | string;
+}
+
+export interface IContentExtractorOptions {
+    content?: Partial<IContentOptions>;
+}
+
+export function validateContentOptions(options: IContentExtractorOptions): void {
+    Validate.optional.booleanProperty(options, 'options.content.trimWhiteSpace');
+    Validate.optional.booleanProperty(options, 'options.content.preserveIndentation');
+    if (options.content && options.content.replaceNewLines !== undefined
+        && options.content.replaceNewLines !== false && typeof options.content.replaceNewLines !== 'string') {
+        throw new TypeError(`Property 'options.content.replaceNewLines' must be false or a string`);
+    }
+}
+
+export function normalizeContent(content: string, options: IContentOptions): string {
+    if (options.trimWhiteSpace) {
+        content = content.replace(/^\n+|\s+$/g, '');
+    }
+    if (!options.preserveIndentation) {
+        content = content.replace(/^[ \t]+/mg, '');
+    }
+    if (typeof options.replaceNewLines === 'string') {
+        content = content.replace(/\n/g, options.replaceNewLines);
+    }
+
+    return content;
+}

--- a/tests/e2e/fixtures/js/example.expected.pot
+++ b/tests/e2e/fixtures/js/example.expected.pot
@@ -2,6 +2,13 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
+#: tests/e2e/fixtures/js/view.jsx:23
+msgid ""
+"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam\n"
+"nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam\n"
+"erat, sed diam voluptua."
+msgstr ""
+
 #: tests/e2e/fixtures/js/view.jsx:22
 msgid "One new message"
 msgid_plural "{{n}} new messages"

--- a/tests/e2e/fixtures/js/view.jsx
+++ b/tests/e2e/fixtures/js/view.jsx
@@ -20,5 +20,9 @@ export class View extends React.Component {
     refresh() {
         let count = Math.round(Math.random() * 100);
         alert(this.translations.plural(count, 'One new message', '{{n}} new messages'));
+        this.translations.get(
+            `Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+            nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+            erat, sed diam voluptua.`);
     }
 }

--- a/tests/e2e/js.test.ts
+++ b/tests/e2e/js.test.ts
@@ -12,6 +12,10 @@ describe('JavaScript E2E', () => {
                     arguments: {
                         text: 0,
                         context: 1
+                    },
+                    content: {
+                        trimWhiteSpace: true,
+                        preserveIndentation: false
                     }
                 }),
                 JsExtractors.callExpression('[this].translations.plural', {

--- a/tests/js/extractors/factories/callExpression.test.ts
+++ b/tests/js/extractors/factories/callExpression.test.ts
@@ -97,6 +97,62 @@ describe('JS: Call Expression Extractor', () => {
                     }
                 ]);
             });
+
+            test('template literals', () => {
+                parser.parseString('service.getText(`Foo`);');
+                parser.parseString('service.getText(`Foo`, `Context`);');
+                parser.parseString('service.getText(`Bar ${substitution}`);');
+
+                expect(messages).toEqual([
+                    {
+                        text: 'Foo'
+                    },
+                    {
+                        text: 'Foo',
+                        context: 'Context'
+                    }
+                ]);
+            });
+
+            test('multi-line template literals', () => {
+                parser.parseString(`service.getText(
+                    \`Line one
+                    Line two
+                    Line three\`
+                );`);
+
+                expect(messages).toEqual([
+                    {
+                        text: 'Line one\n                    Line two\n                    Line three'
+                    }
+                ]);
+            });
+
+            test('content options', () => {
+                parser = createParser('service.getText', {
+                    arguments: {
+                        text: 0,
+                        context: 1
+                    },
+                    content: {
+                        trimWhiteSpace: true,
+                        preserveIndentation: false,
+                        replaceNewLines: ' '
+                    }
+                });
+
+                parser.parseString(`service.getText(
+                    \`Line one
+                    Line two
+                    Line three\`
+                );`);
+
+                expect(messages).toEqual([
+                    {
+                        text: 'Line one Line two Line three'
+                    }
+                ]);
+            });
         });
 
         describe('plural', () => {
@@ -175,6 +231,73 @@ describe('JS: Call Expression Extractor', () => {
                         text: 'Foo',
                         textPlural: 'Foos',
                         context: 'Context'
+                    }
+                ]);
+            });
+
+            test('template literals', () => {
+                parser.parseString('service.getPlural(1, `Foo`, `Foos`);');
+                parser.parseString('service.getPlural(1, `Foo`, `Foos`, `Context`);');
+                parser.parseString('service.getPlural(1, `${count} Bar`, `${count} Bars);');
+
+                expect(messages).toEqual([
+                    {
+                        text: 'Foo',
+                        textPlural: 'Foos'
+                    },
+                    {
+                        text: 'Foo',
+                        textPlural: 'Foos',
+                        context: 'Context'
+                    }
+                ]);
+            });
+
+            test('multi-line template literals', () => {
+                parser.parseString(`service.getPlural(1,
+                    \`Line one
+                    Line two
+                    Line three\`,
+                    \`Line ones
+                    Line twos
+                    Line threes\`
+                );`);
+
+                expect(messages).toEqual([
+                    {
+                        text: 'Line one\n                    Line two\n                    Line three',
+                        textPlural: 'Line ones\n                    Line twos\n                    Line threes'
+                    }
+                ]);
+            });
+
+            test('content options', () => {
+                parser = createParser('service.getPlural', {
+                    arguments: {
+                        text: 1,
+                        textPlural: 2,
+                        context: 3
+                    },
+                    content: {
+                        trimWhiteSpace: true,
+                        preserveIndentation: false,
+                        replaceNewLines: ' '
+                    }
+                });
+
+                parser.parseString(`service.getPlural(1,
+                    \`Line one
+                    Line two
+                    Line three\`,
+                    \`Line ones
+                    Line twos
+                    Line threes\`
+                );`);
+
+                expect(messages).toEqual([
+                    {
+                        text: 'Line one Line two Line three',
+                        textPlural: 'Line ones Line twos Line threes'
                     }
                 ]);
             });
@@ -523,6 +646,69 @@ describe('JS: Call Expression Extractor', () => {
                     }
                 });
             }).toThrowError(`Property 'options.comments.sameLineTrailing' must be a boolean`);
+        });
+
+        test('options.content: wrong type', () => {
+            expect(() => {
+                (<any>callExpressionExtractor)('service.getText', {
+                    arguments: {
+                        text: 1
+                    },
+                    content: 'foo'
+                });
+            }).toThrowError(`Property 'options.content' must be an object`);
+        });
+
+        test('options.content.trimWhiteSpace: wrong type', () => {
+            expect(() => {
+                (<any>callExpressionExtractor)('service.getText', {
+                    arguments: {
+                        text: 1
+                    },
+                    content: {
+                        trimWhiteSpace: 'foo'
+                    }
+                });
+            }).toThrowError(`Property 'options.content.trimWhiteSpace' must be a boolean`);
+        });
+
+        test('options.content.preserveIndentation: wrong type', () => {
+            expect(() => {
+                (<any>callExpressionExtractor)('service.getText', {
+                    arguments: {
+                        text: 1
+                    },
+                    content: {
+                        preserveIndentation: 'foo'
+                    }
+                });
+            }).toThrowError(`Property 'options.content.preserveIndentation' must be a boolean`);
+        });
+
+        test('options.content.replaceNewLines: wrong type', () => {
+            expect(() => {
+                (<any>callExpressionExtractor)('service.getText', {
+                    arguments: {
+                        text: 1
+                    },
+                    content: {
+                        replaceNewLines: 42
+                    }
+                });
+            }).toThrowError(`Property 'options.content.replaceNewLines' must be false or a string`);
+        });
+
+        test('options.content.replaceNewLines: true', () => {
+            expect(() => {
+                (<any>callExpressionExtractor)('service.getText', {
+                    arguments: {
+                        text: 1
+                    },
+                    content: {
+                        replaceNewLines: true
+                    }
+                });
+            }).toThrowError(`Property 'options.content.replaceNewLines' must be false or a string`);
         });
     });
 });


### PR DESCRIPTION
This should fix the extraction of template literals. Template literals with substitutions are ignored (see #12).

Additionally the `callExpression` extractor now supports the same `content` option as the `elementContent` extractor to normalize template literals.