### PR TITLE
Update pofile and parse5 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "css-selector-parser": "^1.3",
         "glob": "5 - 7",
-        "parse5": "^3",
+        "parse5": "^5",
         "pofile": "^1",
         "typescript": "^2"
     },
@@ -42,6 +42,7 @@
         "@types/glob": "^5.0.30",
         "@types/jest": "^20.0.2",
         "@types/node": "^8.0.13",
+        "@types/parse5": "^5.0.0",
         "jest": "^20.0.4",
         "ts-jest": "^20.0.7",
         "tslint": "^5.5.0"

--- a/src/html/extractors/factories/embeddedJs.ts
+++ b/src/html/extractors/factories/embeddedJs.ts
@@ -24,7 +24,7 @@ export function embeddedJsExtractor(selector: string, jsParser: JsParser): IHtml
                 replaceNewLines: false
             });
             jsParser.parseString(source, fileName, {
-                lineNumberStart: element.__location && element.__location.line
+                lineNumberStart: element.sourceCodeLocation && element.sourceCodeLocation.startLine
             });
         }
     };

--- a/src/html/parser.ts
+++ b/src/html/parser.ts
@@ -3,24 +3,24 @@ import * as parse5 from 'parse5';
 import { Parser, IAddMessageCallback, IParseOptions } from '../parser';
 import { IMessage } from '../builder';
 
-export type Node = parse5.AST.Default.Node;
-export type TextNode = parse5.AST.Default.TextNode;
-export type Element = parse5.AST.Default.Element;
+export type Node = parse5.DefaultTreeNode;
+export type TextNode = parse5.DefaultTreeTextNode;
+export type Element = parse5.DefaultTreeElement;
 
 export type IHtmlExtractorFunction = (node: Node, fileName: string, addMessage: IAddMessageCallback) => void;
 
 export class HtmlParser extends Parser<IHtmlExtractorFunction, IParseOptions> {
 
     protected parse(source: string, fileName: string, options: IParseOptions = {}): IMessage[] {
-        let document = parse5.parse(source, {locationInfo: true});
+        let document = parse5.parse(source, {sourceCodeLocationInfo: true});
         return this.parseNode(document, fileName, options.lineNumberStart || 1);
     }
 
     protected parseNode(node: any, fileName: string, lineNumberStart: number): IMessage[] {
         let messages: IMessage[] = [];
         let addMessageCallback = Parser.createAddMessageCallback(messages, fileName, () => {
-            if (node.__location && node.__location.line) {
-                return lineNumberStart + node.__location.line - 1;
+            if (node.sourceCodeLocation && node.sourceCodeLocation.startLine) {
+                return lineNumberStart + node.sourceCodeLocation.startLine - 1;
             }
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,8 +1807,8 @@ pkg-dir@^2.0.0:
     find-up "^2.1.0"
 
 pofile@^1:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/pofile/-/pofile-1.0.8.tgz#09246a1788035404fc4d1ee087fa5e9ea686567d"
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pofile/-/pofile-1.0.11.tgz#35aff58c17491d127a07336d5522ebc9df57c954"
 
 prelude-ls@~1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,13 +52,13 @@
   version "7.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.27.tgz#ba5e1a87aca2b4f5817289615ffe56472927687e"
 
-"@types/node@^6.0.46":
-  version "6.0.68"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.68.tgz#0c43b6b8b9445feb86a0fbd3457e3f4bc591e66d"
-
 "@types/node@^8.0.13":
   version "8.0.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.13.tgz#530f0f9254209b0335bf5cc6387822594ef47093"
+
+"@types/parse5@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.0.tgz#9ae2106efc443d7c1e26570aa8247828c9c80f11"
 
 abab@^1.0.3:
   version "1.0.3"
@@ -1740,11 +1740,9 @@ parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
-parse5@^3:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.2.tgz#05eff57f0ef4577fb144a79f8b9a967a6cc44510"
-  dependencies:
-    "@types/node" "^6.0.46"
+parse5@^5:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.0.0.tgz#4d02710d44f3c3846197a11e205d4ef17842b81a"
 
 path-exists@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
I didn't forward `pofile` in the package.json, but `parse5` already is two major versions ahead.