### PR TITLE
Fix parsing empty line comments

### DIFF
--- a/src/js/extractors/comments.ts
+++ b/src/js/extractors/comments.ts
@@ -175,7 +175,7 @@ export abstract class JsCommentUtils {
                 comment = match ? (match[1] || match[0]) : null;
             }
 
-            if (comment) {
+            if (comment || comment === '') {
                 comments.push(comment);
             }
         }

--- a/tests/js/extractors/comments.test.ts
+++ b/tests/js/extractors/comments.test.ts
@@ -84,6 +84,17 @@ describe('JS: comments', () => {
                 });
             });
 
+            test('empty comment in between the leading lines', () => {
+                check(`
+                    // The first leading line comment
+                    //
+                    // The last leading line comment
+                    getText('Foo');
+                `, {
+                    otherLineLeading: ['The first leading line comment', '', 'The last leading line comment']
+                });
+            });
+
             test('leading line with space', () => {
                 check(`
                     // Leading line comment with space


### PR DESCRIPTION
This PR fixes the issue described in #23 by including the empty line comments into the output.

The fix is trivial but there are few things I'd like to suggest to improve the codebase to prevent the similar bugs from happening again:

1. First of all, tightening up the TypeScript configuration would prevent the code to compile and thus let the buggy code slip into production. The codebase is very loosely typed, I'd definitely turn on `strict: true` in `tsconfig.json`, consider the following example:

```ts
private static extractLineComment(source: string): string // return type is a string
{
  let match = source.match(/^\/\/\s*(.*?)\s*$/);
  return match ? match[1] : null; // but sometimes it returns null
}
```

2. Use `const` instead of `let` in immutable contexts. Same example:

```diff
private static extractLineComment(source: string): string
{
+ // prefer const over let, because match is meant to be immutable
-  let match = source.match(/^\/\/\s*(.*?)\s*$/);
+  const match = source.match(/^\/\/\s*(.*?)\s*$/);
  return match ? match[1] : null;
}
```