### PR TITLE
Move types dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,19 +32,19 @@
         "node": ">=6"
     },
     "dependencies": {
-        "@types/glob": "5 - 7",
-        "@types/parse5": "^5",
         "css-selector-parser": "^1.3",
         "glob": "5 - 7",
         "parse5": "^5",
         "pofile": "^1",
-        "typescript": "2 - 3"
     },
     "devDependencies": {
         "@types/jest": "^23.3.5",
         "@types/node": "^10.11.6",
+        "@types/glob": "5 - 7",
+        "@types/parse5": "^5",
         "jest": "^23.6.0",
         "ts-jest": "^23.10.4",
-        "tslint": "^5.11.0"
+        "tslint": "^5.11.0",
+        "typescript": "2 - 3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "css-selector-parser": "^1.3",
         "glob": "5 - 7",
         "parse5": "^5",
-        "pofile": "^1",
+        "pofile": "^1"
     },
     "devDependencies": {
         "@types/jest": "^23.3.5",


### PR DESCRIPTION
This can cause projects when brought into other projects. They should be development dependencies only.