### PR TITLE
Fix typescript build

### DIFF
--- a/src/html/selector.ts
+++ b/src/html/selector.ts
@@ -88,7 +88,7 @@ export class ElementSelectorSet {
     }
 
     public anyMatch(element: Element): boolean {
-        return this.selectors.reduce((matched, s) => matched || s.matches(element), false);
+        return this.selectors.reduce((matched, s) => matched || s.matches(element), false as boolean);
     }
 
     public allMatch(element: Element): boolean {


### PR DESCRIPTION
At one point typescript made inferrence stricter, and the "false" argument is now literal false instead of boolean which causes an error. With this trivial fix everything works on typescript@3.9.7 for me
~~~
$ npm run test

> gettext-extractor@3.5.2 test /home/vbraun/Code/gettext-extractor
> jest --config jest.json

 PASS  tests/parser.test.ts
 FAIL  tests/html/extractors/factories/embeddedJs.test.ts
  ● Test suite failed to run

    TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
    src/html/selector.ts:91:9 - error TS2322: Type 'ElementSelector' is not assignable to type 'boolean'.

    91         return this.selectors.reduce((matched, s) => matched || s.matches(element), false);
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    src/html/selector.ts:91:54 - error TS2769: No overload matches this call.
      Overload 1 of 3, '(callbackfn: (previousValue: ElementSelector, currentValue: ElementSelector, currentIndex: number, array: ElementSelector[]) => ElementSelector, initialValue: ElementSelector): ElementSelector', gave the following error.
        Type 'boolean' is not assignable to type 'ElementSelector'.
      Overload 2 of 3, '(callbackfn: (previousValue: false, currentValue: ElementSelector, currentIndex: number, array: ElementSelector[]) => false, initialValue: false): false', gave the following error.
        Type 'boolean' is not assignable to type 'false'.

    91         return this.selectors.reduce((matched, s) => matched || s.matches(element), false);
                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

      node_modules/typescript/lib/lib.es5.d.ts:1350:24
        1350     reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        The expected type comes from the return type of this signature.
      node_modules/typescript/lib/lib.es5.d.ts:1356:27
        1356     reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        The expected type comes from the return type of this signature.
~~~