### PR TITLE
Provide content options for HTML attribute extractor (fixes #56)

### DIFF
--- a/src/html/extractors/common.ts
+++ b/src/html/extractors/common.ts
@@ -1,4 +1,5 @@
 import { Validate } from '../../utils/validate';
+import { IContentExtractorOptions } from '../../utils/content';
 
 export interface IAttributeMapping {
     textPlural?: string;
@@ -6,7 +7,7 @@ export interface IAttributeMapping {
     comment?: string;
 }
 
-export interface IHtmlExtractorOptions {
+export interface IHtmlExtractorOptions extends IContentExtractorOptions {
     attributes?: IAttributeMapping;
 }
 

--- a/src/html/extractors/factories/element.ts
+++ b/src/html/extractors/factories/element.ts
@@ -4,6 +4,7 @@ import { IElementSelector, ElementSelectorSet } from '../../selector';
 import { Element, Node } from '../../parser';
 import { HtmlUtils } from '../../utils';
 import { IHtmlExtractorOptions } from '../common';
+import { getContentOptions, IContentOptions } from '../../../utils/content';
 
 export type ITextExtractor = (element: Element) => string | null;
 
@@ -21,18 +22,23 @@ export function elementExtractor(selector: string | IElementSelector[], textExtr
         if (selectors.anyMatch(element)) {
             let context: string | undefined,
                 textPlural: string | undefined,
-                comments: string[] = [];
+                comments: string[] = [],
+                contentOptions: IContentOptions = getContentOptions(options, {
+                    trimWhiteSpace: true,
+                    preserveIndentation: false,
+                    replaceNewLines: false
+                });
 
             if (options.attributes && options.attributes.context) {
-                context = HtmlUtils.getAttributeValue(element, options.attributes.context) || undefined;
+                context = HtmlUtils.getNormalizedAttributeValue(element, options.attributes.context, contentOptions) || undefined;
             }
 
             if (options.attributes && options.attributes.textPlural) {
-                textPlural = HtmlUtils.getAttributeValue(element, options.attributes.textPlural) || undefined;
+                textPlural = HtmlUtils.getNormalizedAttributeValue(element, options.attributes.textPlural, contentOptions) || undefined;
             }
 
             if (options.attributes && options.attributes.comment) {
-                let comment = HtmlUtils.getAttributeValue(element, options.attributes.comment);
+                let comment = HtmlUtils.getNormalizedAttributeValue(element, options.attributes.comment, contentOptions);
                 if (comment) {
                     comments.push(comment);
                 }

--- a/src/html/extractors/factories/elementAttribute.ts
+++ b/src/html/extractors/factories/elementAttribute.ts
@@ -3,12 +3,20 @@ import { HtmlUtils } from '../../utils';
 import { elementExtractor } from './element';
 import { Validate } from '../../../utils/validate';
 import { IHtmlExtractorOptions, validateOptions } from '../common';
+import { IContentOptions, getContentOptions, validateContentOptions } from '../../../utils/content';
 
 export function elementAttributeExtractor(selector: string, textAttribute: string, options: IHtmlExtractorOptions = {}): IHtmlExtractorFunction {
     Validate.required.nonEmptyString({selector, textAttribute});
     validateOptions(options);
+    validateContentOptions(options);
+
+    let contentOptions: IContentOptions = getContentOptions(options, {
+        trimWhiteSpace: false,
+        preserveIndentation: true,
+        replaceNewLines: false
+    });
 
     return elementExtractor(selector, element => {
-        return HtmlUtils.getAttributeValue(element, textAttribute);
+        return HtmlUtils.getNormalizedAttributeValue(element, textAttribute, contentOptions);
     }, options);
 }

--- a/src/html/extractors/factories/elementContent.ts
+++ b/src/html/extractors/factories/elementContent.ts
@@ -1,34 +1,20 @@
 import { IHtmlExtractorFunction } from '../../parser';
 import { HtmlUtils } from '../../utils';
 import { Validate } from '../../../utils/validate';
-import { IContentOptions, IContentExtractorOptions, validateContentOptions } from '../../../utils/content';
+import { getContentOptions, IContentOptions, validateContentOptions } from '../../../utils/content';
 import { IHtmlExtractorOptions, validateOptions } from '../common';
 import { elementExtractor } from './element';
 
-export interface IElementContentExtractorOptions extends IHtmlExtractorOptions, IContentExtractorOptions {}
-
-export function elementContentExtractor(selector: string, options: IElementContentExtractorOptions = {}): IHtmlExtractorFunction {
+export function elementContentExtractor(selector: string, options: IHtmlExtractorOptions = {}): IHtmlExtractorFunction {
     Validate.required.nonEmptyString({selector});
     validateOptions(options);
     validateContentOptions(options);
 
-    let contentOptions: IContentOptions = {
+    let contentOptions: IContentOptions = getContentOptions(options, {
         trimWhiteSpace: true,
         preserveIndentation: false,
         replaceNewLines: false
-    };
-
-    if (options.content) {
-        if (options.content.trimWhiteSpace !== undefined) {
-            contentOptions.trimWhiteSpace = options.content.trimWhiteSpace;
-        }
-        if (options.content.preserveIndentation !== undefined) {
-            contentOptions.preserveIndentation = options.content.preserveIndentation;
-        }
-        if (options.content.replaceNewLines !== undefined) {
-            contentOptions.replaceNewLines = options.content.replaceNewLines;
-        }
-    }
+    });
 
     return elementExtractor(selector, element => {
         return HtmlUtils.getElementContent(element, contentOptions);

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -11,7 +11,17 @@ export abstract class HtmlUtils {
                 return attribute.value;
             }
         }
+
         return null;
+    }
+
+    public static getNormalizedAttributeValue(element: Element, attributeName: string, options: IContentOptions): string | null {
+        let value = HtmlUtils.getAttributeValue(element, attributeName);
+        if (value === null) {
+            return null;
+        }
+
+        return normalizeContent(value, options);
     }
 
     public static getElementContent(element: Element, options: IContentOptions): string {

--- a/src/js/extractors/factories/callExpression.ts
+++ b/src/js/extractors/factories/callExpression.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 
 import { IJsExtractorFunction } from '../../parser';
 import { Validate } from '../../../utils/validate';
-import { IContentOptions, normalizeContent, validateContentOptions } from '../../../utils/content';
+import { IContentOptions, normalizeContent, getContentOptions, validateContentOptions } from '../../../utils/content';
 import { IJsExtractorOptions, validateOptions, IArgumentIndexMapping } from '../common';
 import { JsUtils } from '../../utils';
 import { IAddMessageCallback, IMessageData } from '../../../parser';
@@ -22,23 +22,11 @@ export function callExpressionExtractor(calleeName: string | string[], options: 
     validateOptions(options);
     validateContentOptions(options);
 
-    let contentOptions: IContentOptions = {
+    let contentOptions: IContentOptions = getContentOptions(options, {
         trimWhiteSpace: false,
         preserveIndentation: true,
         replaceNewLines: false
-    };
-
-    if (options.content) {
-        if (options.content.trimWhiteSpace !== undefined) {
-            contentOptions.trimWhiteSpace = options.content.trimWhiteSpace;
-        }
-        if (options.content.preserveIndentation !== undefined) {
-            contentOptions.preserveIndentation = options.content.preserveIndentation;
-        }
-        if (options.content.replaceNewLines !== undefined) {
-            contentOptions.replaceNewLines = options.content.replaceNewLines;
-        }
-    }
+    });
 
     return (node: ts.Node, sourceFile: ts.SourceFile, addMessage: IAddMessageCallback) => {
         if (node.kind === ts.SyntaxKind.CallExpression) {

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -10,6 +10,24 @@ export interface IContentExtractorOptions {
     content?: Partial<IContentOptions>;
 }
 
+export function getContentOptions(extractorOptions: IContentExtractorOptions, defaultOptions: IContentOptions): IContentOptions {
+    let contentOptions = defaultOptions;
+
+    if (extractorOptions.content) {
+        if (extractorOptions.content.trimWhiteSpace !== undefined) {
+            contentOptions.trimWhiteSpace = extractorOptions.content.trimWhiteSpace;
+        }
+        if (extractorOptions.content.preserveIndentation !== undefined) {
+            contentOptions.preserveIndentation = extractorOptions.content.preserveIndentation;
+        }
+        if (extractorOptions.content.replaceNewLines !== undefined) {
+            contentOptions.replaceNewLines = extractorOptions.content.replaceNewLines;
+        }
+    }
+
+    return contentOptions;
+}
+
 export function validateContentOptions(options: IContentExtractorOptions): void {
     Validate.optional.booleanProperty(options, 'options.content.trimWhiteSpace');
     Validate.optional.booleanProperty(options, 'options.content.preserveIndentation');

--- a/tests/e2e/html/elementAttribute.test.ts
+++ b/tests/e2e/html/elementAttribute.test.ts
@@ -222,6 +222,54 @@ describe('argument validation', () => {
             });
         }).toThrowError(`Property 'options.attributes.comment' must be a string`);
     });
+
+    test('options.content: wrong type', () => {
+        expect(() => {
+            (<any>HtmlExtractors.elementAttribute)('[translate]', 'translate', {
+                content: 'foo'
+            });
+        }).toThrowError(`Property 'options.content' must be an object`);
+    });
+
+    test('options.content.trimWhiteSpace: wrong type', () => {
+        expect(() => {
+            (<any>HtmlExtractors.elementAttribute)('[translate]', 'translate', {
+                content: {
+                    trimWhiteSpace: 'foo'
+                }
+            });
+        }).toThrowError(`Property 'options.content.trimWhiteSpace' must be a boolean`);
+    });
+
+    test('options.content.preserveIndentation: wrong type', () => {
+        expect(() => {
+            (<any>HtmlExtractors.elementAttribute)('[translate]', 'translate', {
+                content: {
+                    preserveIndentation: 'foo'
+                }
+            });
+        }).toThrowError(`Property 'options.content.preserveIndentation' must be a boolean`);
+    });
+
+    test('options.content.replaceNewLines: wrong type', () => {
+        expect(() => {
+            (<any>HtmlExtractors.elementAttribute)('[translate]', 'translate', {
+                content: {
+                    replaceNewLines: 42
+                }
+            });
+        }).toThrowError(`Property 'options.content.replaceNewLines' must be false or a string`);
+    });
+
+    test('options.content.replaceNewLines: true', () => {
+        expect(() => {
+            (<any>HtmlExtractors.elementAttribute)('[translate]', 'translate', {
+                content: {
+                    replaceNewLines: true
+                }
+            });
+        }).toThrowError(`Property 'options.content.replaceNewLines' must be false or a string`);
+    });
 });
 
 function assertMessages(extractorFunction: IHtmlExtractorFunction, source: string, ...expected: Partial<IMessage>[]): () => void {

--- a/tests/html/extractors/factories/elementAttribute.test.ts
+++ b/tests/html/extractors/factories/elementAttribute.test.ts
@@ -1,6 +1,7 @@
 import { HtmlParser } from '../../../../src/html/parser';
 import { CatalogBuilder, IMessage } from '../../../../src/builder';
 import { elementAttributeExtractor } from '../../../../src/html/extractors/factories/elementAttribute';
+import { elementContentExtractor } from '../../../../src/html/extractors/factories/elementContent';
 
 describe('HTML: Element Attribute Extractor', () => {
 
@@ -247,6 +248,98 @@ describe('HTML: Element Attribute Extractor', () => {
                     }
                 });
             }).toThrowError(`Property 'options.attributes.comment' must be a string`);
+        });
+
+        test('options.content: wrong type', () => {
+            expect(() => {
+                (<any>elementContentExtractor)('[translate]', {
+                    content: 'foo'
+                });
+            }).toThrowError(`Property 'options.content' must be an object`);
+        });
+
+        test('options.content.trimWhiteSpace: wrong type', () => {
+            expect(() => {
+                (<any>elementContentExtractor)('[translate]', {
+                    content: {
+                        trimWhiteSpace: 'foo'
+                    }
+                });
+            }).toThrowError(`Property 'options.content.trimWhiteSpace' must be a boolean`);
+        });
+
+        test('options.content.preserveIndentation: wrong type', () => {
+            expect(() => {
+                (<any>elementContentExtractor)('[translate]', {
+                    content: {
+                        preserveIndentation: 'foo'
+                    }
+                });
+            }).toThrowError(`Property 'options.content.preserveIndentation' must be a boolean`);
+        });
+
+        test('options.content.replaceNewLines: wrong type', () => {
+            expect(() => {
+                (<any>elementContentExtractor)('[translate]', {
+                    content: {
+                        replaceNewLines: 42
+                    }
+                });
+            }).toThrowError(`Property 'options.content.replaceNewLines' must be false or a string`);
+        });
+
+        test('options.content.replaceNewLines: true', () => {
+            expect(() => {
+                (<any>elementContentExtractor)('[translate]', {
+                    content: {
+                        replaceNewLines: true
+                    }
+                });
+            }).toThrowError(`Property 'options.content.replaceNewLines' must be false or a string`);
+        });
+    });
+
+    describe('argument proxying', () => {
+        test('options.content.options: applies for all attributes', () => {
+            parser = new HtmlParser(builder, [
+                elementAttributeExtractor('translate', 'text', {
+                    attributes: {
+                        textPlural: 'plural',
+                        context: 'context',
+                        comment: 'comment'
+                    },
+                    content: {
+                        preserveIndentation: false,
+                        replaceNewLines: '',
+                        trimWhiteSpace: true
+                    }
+                })
+            ]);
+
+            parser.parseString(`
+                <translate
+                    text="
+                        Foo
+                    "
+                    plural="
+                        Foos
+                    "
+                    comment="
+                        Comment
+                    "
+                    context="
+                        Context
+                    "/>
+            `);
+
+            expect(messages).toEqual([
+                {
+                    text: 'Foo',
+                    textPlural: 'Foos',
+                    context: 'Context',
+                    comments: ['Comment']
+                }
+            ]);
         });
     });
 });

--- a/tests/html/extractors/factories/elementContent.test.ts
+++ b/tests/html/extractors/factories/elementContent.test.ts
@@ -273,4 +273,47 @@ describe('HTML: Element Content Extractor', () => {
             }).toThrowError(`Property 'options.content.replaceNewLines' must be false or a string`);
         });
     });
+
+    describe('argument proxying', () => {
+        test('options.content.options: applies for all attributes', () => {
+            parser = new HtmlParser(builder, [
+                elementContentExtractor('translate', {
+                    attributes: {
+                        textPlural: 'plural',
+                        context: 'context',
+                        comment: 'comment'
+                    },
+                    content: {
+                        preserveIndentation: false,
+                        replaceNewLines: '',
+                        trimWhiteSpace: true
+                    }
+                })
+            ]);
+
+            parser.parseString(`
+                <translate
+                    plural="
+                        Foos
+                    "
+                    comment="
+                        Comment
+                    "
+                    context="
+                        Context
+                    ">
+                    Foo
+                </translate>
+            `);
+
+            expect(messages).toEqual([
+                {
+                    text: 'Foo',
+                    textPlural: 'Foos',
+                    context: 'Context',
+                    comments: ['Comment']
+                }
+            ]);
+        });
+    });
 });

--- a/tests/html/utils.test.ts
+++ b/tests/html/utils.test.ts
@@ -35,6 +35,34 @@ describe('HTML: Utils', () => {
         });
     });
 
+    describe('getNormalizedAttributeValue', () => {
+
+        test('indendation', () => {
+            expect(HtmlUtils.getNormalizedAttributeValue(createElement('<div foo="\n' +
+                '   Foo\n' +
+                '   Bar\n' +
+                '" />'), 'foo', {
+                    preserveIndentation: true,
+                    trimWhiteSpace: true,
+                    replaceNewLines: false
+                })).toBe(
+                '   Foo\n' +
+                '   Bar'
+            );
+        });
+
+        test('new lines', () => {
+            expect(HtmlUtils.getNormalizedAttributeValue(createElement('<div foo="\n' +
+                '   Foo\n' +
+                '   Bar\n' +
+                '" />'), 'foo', {
+                preserveIndentation: false,
+                trimWhiteSpace: true,
+                replaceNewLines: ' '
+            })).toBe('Foo Bar');
+        });
+    });
+
     describe('getElementContent', () => {
 
         function getContent(source: string): string {


### PR DESCRIPTION
Hi Lukas,

this PR introduces the possibility to use content options for `HtmlExtractors.elementAttribute` the same way as for `HtmlExtractors.elementContent`. As usages including default values should very likely be the same I had to move some code into utils for reusability. Besides, all attributes being used get the same content options applied, which was added in the primitive element extractor. Tests should cover these scenarios.

Looking forward to your feedback, thanks!