### PR TITLE
fix lineNumberStart on html parse

### DIFF
--- a/src/html/extractors/factories/embeddedJs.ts
+++ b/src/html/extractors/factories/embeddedJs.ts
@@ -24,10 +24,12 @@ export function embeddedJsExtractor(selector: string, jsParser: JsParser): IHtml
                 replaceNewLines: false
             });
             if (element.sourceCodeLocation && element.sourceCodeLocation.startLine) {
-                lineNumberStart = lineNumberStart + element.sourceCodeLocation.startLine - 1;
+                lineNumberStart = lineNumberStart + element.sourceCodeLocation.startLine;
             }
             jsParser.parseString(source, fileName, {
-                lineNumberStart
+                // since in src/js/parser.ts we have return `lineNumberStart + location.line(1-based)`
+                // so here should minus one
+                lineNumberStart: lineNumberStart - 1
             });
         }
     };

--- a/src/html/extractors/factories/embeddedJs.ts
+++ b/src/html/extractors/factories/embeddedJs.ts
@@ -5,12 +5,12 @@ import { HtmlUtils } from '../../utils';
 import { Validate } from '../../../utils/validate';
 
 export function embeddedJsExtractor(selector: string, jsParser: JsParser): IHtmlExtractorFunction {
-    Validate.required.nonEmptyString({selector});
-    Validate.required.argument({jsParser});
+    Validate.required.nonEmptyString({ selector });
+    Validate.required.argument({ jsParser });
 
     let selectors = new ElementSelectorSet(selector);
 
-    return (node: Node, fileName: string) => {
+    return (node: Node, fileName: string, _, lineNumberStart) => {
         if (typeof (<Element>node).tagName !== 'string') {
             return;
         }
@@ -23,8 +23,11 @@ export function embeddedJsExtractor(selector: string, jsParser: JsParser): IHtml
                 preserveIndentation: true,
                 replaceNewLines: false
             });
+            if (element.sourceCodeLocation && element.sourceCodeLocation.startLine) {
+                lineNumberStart = lineNumberStart + element.sourceCodeLocation.startLine - 1;
+            }
             jsParser.parseString(source, fileName, {
-                lineNumberStart: element.sourceCodeLocation && element.sourceCodeLocation.startLine
+                lineNumberStart
             });
         }
     };

--- a/src/html/extractors/factories/embeddedJs.ts
+++ b/src/html/extractors/factories/embeddedJs.ts
@@ -24,12 +24,10 @@ export function embeddedJsExtractor(selector: string, jsParser: JsParser): IHtml
                 replaceNewLines: false
             });
             if (element.sourceCodeLocation && element.sourceCodeLocation.startLine) {
-                lineNumberStart = lineNumberStart + element.sourceCodeLocation.startLine;
+                lineNumberStart = lineNumberStart + element.sourceCodeLocation.startLine - 1;
             }
             jsParser.parseString(source, fileName, {
-                // since in src/js/parser.ts we have return `lineNumberStart + location.line(1-based)`
-                // so here should minus one
-                lineNumberStart: lineNumberStart - 1
+                lineNumberStart
             });
         }
     };

--- a/src/html/parser.ts
+++ b/src/html/parser.ts
@@ -7,7 +7,7 @@ export type Node = parse5.DefaultTreeNode;
 export type TextNode = parse5.DefaultTreeTextNode;
 export type Element = parse5.DefaultTreeElement;
 
-export type IHtmlExtractorFunction = (node: Node, fileName: string, addMessage: IAddMessageCallback) => void;
+export type IHtmlExtractorFunction = (node: Node, fileName: string, addMessage: IAddMessageCallback, lineNumberStart: number) => void;
 
 export class HtmlParser extends Parser<IHtmlExtractorFunction, IParseOptions> {
 
@@ -25,7 +25,7 @@ export class HtmlParser extends Parser<IHtmlExtractorFunction, IParseOptions> {
         });
 
         for (let extractor of this.extractors) {
-            extractor(node, fileName, addMessageCallback);
+            extractor(node, fileName, addMessageCallback, lineNumberStart);
         }
 
         let childNodes = node.content ? node.content.childNodes : node.childNodes;

--- a/tests/html/extractors/factories/embeddedJs.test.ts
+++ b/tests/html/extractors/factories/embeddedJs.test.ts
@@ -27,6 +27,14 @@ describe('HTML: Embedded JS Extractor', () => {
             });
         });
 
+        test('with lineNumberStart option', () => {
+            htmlParser.parseString(`<script>Foo</script>`, 'foo.html', { lineNumberStart: 10 });
+
+            expect(jsParserMock.parseString).toHaveBeenCalledWith('Foo', 'foo.html', {
+                lineNumberStart: 10
+            });
+        });
+
         test('separate line', () => {
             htmlParser.parseString(`<script>\nFoo\n</script>`, 'foo.html');
 


### PR DESCRIPTION
First of all, thank you for this great project.

However, when using it (I use https://github.com/jshmrtn/vue3-gettext, which relies on this project to extract the translation messages from the .vue file), I found a small problem:

When the `lineNumberStart` option is passed to `HTMLParser` to parse, the option fails.
Cause in `embeddedJsExtractor` function, a new option has been passed to jsParser.

So I update the `IHtmlExtractorFunction` type, added a lineNumberStart arg to fix it.

Please take some time to review this~