### PR TITLE
allow typescript v5 in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "glob": "5 - 7",
         "parse5": "5 - 6",
         "pofile": "1.0.x",
-        "typescript": "2 - 4"
+        "typescript": "2 - 5"
     },
     "devDependencies": {
         "@types/jest": "^26.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,7 +3494,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-"typescript@2 - 4":
+"typescript@2 - 5":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
   integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==


### PR DESCRIPTION
[typescript v5.0](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/) has been released on 16.03.2023.