### PR TITLE
Allow chalk 5+

### DIFF
--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -3,7 +3,8 @@ import { Chalk } from 'chalk';
 
 let chalk: Chalk | undefined;
 try {
-    chalk = require('chalk');
+    const chalkPackage = require('chalk');
+    chalk = chalkPackage?.default || chalkPackage;
 } catch (e) { /* falls back to default colored output */ }
 
 export abstract class OutputUtils {


### PR DESCRIPTION
Updates the import for chalk to allow [chalk 5+](https://github.com/chalk/chalk/releases/tag/v5.0.0)